### PR TITLE
formatting, dark mode, fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -41,7 +41,7 @@ h1 {
   }
 }
 
-/* pauses animation for my retarded fellas */
+/* pauses animation for my silly lil fellas */
 @media (prefers-reduced-motion: reduce) {
   .marquee__content {
     animation-play-state: paused !important;

--- a/css/style.css
+++ b/css/style.css
@@ -16,7 +16,7 @@ h1 {
 
 /* marquee styles ^_^ */
 .marquee {
-  --gap: 1rem;
+  --gap: 0.25rem;
   position: relative;
   display: flex;
   overflow: hidden;
@@ -68,8 +68,8 @@ h1 {
   animation-direction: reverse;
 }
 
-/* pause on hover ?? if i use this */
-.marquee__hover-pause:hover .marquee__content {
+/* pause on hover */
+.enable-animation.marquee:hover > * {
   animation-play-state: paused;
 }
 
@@ -102,7 +102,7 @@ h1 {
 
 @media (prefers-color-scheme: dark) {
   html {
-    background: rgb(13, 13, 13);
-    color: white;
+    background: #0d0d0d;
+    color: #ffffff;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -48,12 +48,12 @@ h1 {
   }
 }
 
-.marquee--top {
+.marquee__top {
   position: fixed;
   top: 0;
 }
 
-.marquee--bot {
+.marquee__bot {
   position: fixed;
   bottom: 0;
 }
@@ -64,29 +64,29 @@ h1 {
 }
 
 /* reverse animation */
-.marquee--reverse .marquee__content {
+.marquee__reverse .marquee__content {
   animation-direction: reverse;
 }
 
 /* pause on hover ?? if i use this */
-.marquee--hover-pause:hover .marquee__content {
+.marquee__hover-pause:hover .marquee__content {
   animation-play-state: paused;
 }
 
 /* size parent based on content. parent width = both */
-.marquee--fit-content {
+.marquee__fit-content {
   max-width: fit-content;
 }
 
 /* a fit-content sizing fix i stole lol */
-.marquee--pos-absolute .marquee__content:last-child {
+.marquee__pos-absolute .marquee__content:last-child {
   position: absolute;
   top: 0;
   left: 0;
 }
 
 /* enable position absolute animation on duplicate */
-.enable-animation .marquee--pos-absolute .marquee__content:last-child {
+.enable-animation .marquee__pos-absolute .marquee__content:last-child {
   animation-name: scroll-abs;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,94 +1,108 @@
-@font-face {
-    font-family: 'Comic Sans MS';
-    src: url("comic-sans-ms/comici.ttf");
+body {
+  cursor: url('../cursor/toro.cur'), auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
-body {
-    cursor: url('cursor/toro.cur'), auto;
+h1 {
+  font-family: 'Comic Sans MS';
+}
+
+#footertext {
+  font-size: 12px;
 }
 
 /* marquee styles ^_^ */
 .marquee {
-    --gap: 1rem;
-    position: relative;
-    display: flex;
-    overflow: hidden;
-    user-select: none;
-    gap: var(--gap);
+  --gap: 1rem;
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  user-select: none;
+  gap: var(--gap);
+}
+
+.marquee__content {
+  flex-shrink: 0;
+  display: flex;
+  justify-content: space-around;
+  gap: var(--gap);
+  min-width: 100%;
+}
+
+@keyframes scroll {
+  from {
+    transform: translateX(0);
   }
-  
+  to {
+    transform: translateX(calc(-100% - var(--gap)));
+  }
+}
+
+/* pauses animation for my retarded fellas */
+@media (prefers-reduced-motion: reduce) {
   .marquee__content {
-    flex-shrink: 0;
-    display: flex;
-    justify-content: space-around;
-    gap: var(--gap);
-    min-width: 100%;
+    animation-play-state: paused !important;
   }
-  
-  @keyframes scroll {
-    from {
-      transform: translateX(0);
-    }
-    to {
-      transform: translateX(calc(-100% - var(--gap)));
-    }
-  }
-  
-  /* pauses animation for my retarded fellas */
-  @media (prefers-reduced-motion: reduce) {
-    .marquee__content {
-      animation-play-state: paused !important;
-    }
-  }
-  
-  .marquee--top {
-    position: fixed;
-    top: 0;
-  }
+}
 
-  .marquee--bot {
-    position: fixed;
-    bottom: 0;
-  }
+.marquee--top {
+  position: fixed;
+  top: 0;
+}
 
-  /* enable animation */
-  .enable-animation .marquee__content {
-    animation: scroll 50s linear infinite;
+.marquee--bot {
+  position: fixed;
+  bottom: 0;
+}
+
+/* enable animation */
+.enable-animation .marquee__content {
+  animation: scroll 50s linear infinite;
+}
+
+/* reverse animation */
+.marquee--reverse .marquee__content {
+  animation-direction: reverse;
+}
+
+/* pause on hover ?? if i use this */
+.marquee--hover-pause:hover .marquee__content {
+  animation-play-state: paused;
+}
+
+/* size parent based on content. parent width = both */
+.marquee--fit-content {
+  max-width: fit-content;
+}
+
+/* a fit-content sizing fix i stole lol */
+.marquee--pos-absolute .marquee__content:last-child {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+/* enable position absolute animation on duplicate */
+.enable-animation .marquee--pos-absolute .marquee__content:last-child {
+  animation-name: scroll-abs;
+}
+
+/* keyframe animation to create illusion of infinite loop by duping container */
+@keyframes scroll-abs {
+  from {
+    transform: translateX(calc(100% + var(--gap)));
   }
-  
-  /* reverse animation */
-  .marquee--reverse .marquee__content {
-    animation-direction: reverse;
+  to {
+    transform: translateX(0);
   }
-  
-  /* pause on hover ?? if i use this */
-  .marquee--hover-pause:hover .marquee__content {
-    animation-play-state: paused;
+}
+
+@media (prefers-color-scheme: dark) {
+  html {
+    background: rgb(13, 13, 13);
+    color: white;
   }
-  
-  /* size parent based on content. parent width = both */
-  .marquee--fit-content {
-    max-width: fit-content;
-  }
-  
-  /* a fit-content sizing fix i stole lol */
-  .marquee--pos-absolute .marquee__content:last-child {
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
-  
-  /* enable position absolute animation on duplicate */
-  .enable-animation .marquee--pos-absolute .marquee__content:last-child {
-    animation-name: scroll-abs;
-  }
-  
-  /* keyframe animation to create illusion of infinite loop by duping container */
-  @keyframes scroll-abs {
-    from {
-      transform: translateX(calc(100% + var(--gap)));
-    }
-    to {
-      transform: translateX(0);
-    }
-  }
+}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ i like to comment my code frequently,
 
 <!-- i was really drunk when i first wrote this and i regret it -->
 <div class="marquee enable-animation marquee-top">
-  <ul class="marquee__content">
+  <p class="marquee__content">
     i love cats :3 i love little kitty cats :3
     i love little kitties :3 love those little kitty cats :3
     i love cats :3 i love little kitty cats :3
@@ -30,9 +30,9 @@ i like to comment my code frequently,
     on october 3rd, 2015 killing 42 civilians and injuring over 30.
     i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3
     meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3
-  </ul>
+  </p>
   <!-- mirrors to create illusion of infinite loop! -->
-  <ul class="marquee__content" aria-hidden="true">
+  <p class="marquee__content" aria-hidden="true">
     i love cats :3 i love little kitty cats :3
     i love little kitties :3 love those little kitty cats :3
     i love cats :3 i love little kitty cats :3
@@ -48,7 +48,7 @@ i like to comment my code frequently,
     on october 3rd, 2015 killing 42 civilians and injuring over 30.
     i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3
     meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3
-  </ul>
+  </p>
 </div>
 
 <!-- page title -->
@@ -93,8 +93,8 @@ i like to comment my code frequently,
   gallery and music soon :)
 </i></p>
 
-<div class="marquee enable-animation marquee--reverse marquee--bot">
-  <ul class="marquee__content">
+<div class="marquee enable-animation marquee__reverse marquee__bot">
+  <p class="marquee__content">
     i love cats :3 i love little kitty cats :3
     i love little kitties :3 love those little kitty cats :3
     i love cats :3 i love little kitty cats :3
@@ -110,9 +110,9 @@ i like to comment my code frequently,
     on october 3rd, 2015 killing 42 civilians and injuring over 30.
     i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3
     meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3
-  </ul>
+  </p>
   <!-- Mirrors the content above -->
-  <ul class="marquee__content" aria-hidden="true">
+  <p class="marquee__content" aria-hidden="true">
     i love cats :3 i love little kitty cats :3
     i love little kitties :3 love those little kitty cats :3
     i love cats :3 i love little kitty cats :3
@@ -128,7 +128,7 @@ i like to comment my code frequently,
     on october 3rd, 2015 killing 42 civilians and injuring over 30.
     i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3
     meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3
-  </ul>
+  </p>
 </div>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -1,64 +1,64 @@
 <!DOCTYPE html>
-<!-- i like to comment my code frequently,
-        clean code is happy code,
-            stay in school kids ^_^ -->
+<!--
+i like to comment my code frequently,
+    clean code is happy code,
+     stay in school kids ^_^
+-->
 <html>
 <head>
-  <title>fangs.cat</title>
+  <title>fangs dot cat</title>
   <link rel="icon" type="image/x-icon" href="/imgs/favicon.ico">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-<style type="text/css">body { cursor: url('cursor/toro.cur'), auto; }</style>
-<center>
 
 <!-- i was really drunk when i first wrote this and i regret it -->
 <div class="marquee enable-animation marquee-top">
   <ul class="marquee__content">
-      i love cats :3 i love little kitty cats :3 
-      i love little kitties :3 love those little kitty cats :3 
-      i love cats :3 i love little kitty cats :3 
-      i love little kitties :3 love those little kitty cats :3 
-      my name is jeff :3 i adore felines :3 big fan of kitties :3 
-      i love cats :3 i love litte kitties :3 love a pretty kitty :3
-      did you guys know sonic had a rough transition into 3D? 
-      too bad though cause i love my little kitties :3 meow :3 
-      nya nya :3 ppurrr~ :3 i think i have mental illness :3 
-      i love cats :3 i love little kitty cats :3 love them :3 
-      i love cats :3 i love cats :3 i love cats :3 meow meow :3 
-      president barack obama sent a drone strike to a kunduz trauma hospital
-      on october 3rd, 2015 killing 42 civilians and injuring over 30. 
-      i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3 
-      meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3
-    </ul>
+    i love cats :3 i love little kitty cats :3
+    i love little kitties :3 love those little kitty cats :3
+    i love cats :3 i love little kitty cats :3
+    i love little kitties :3 love those little kitty cats :3
+    my name is jeff :3 i adore felines :3 big fan of kitties :3
+    i love cats :3 i love litte kitties :3 love a pretty kitty :3
+    did you guys know sonic had a rough transition into 3D?
+    too bad though cause i love my little kitties :3 meow :3
+    nya nya :3 ppurrr~ :3 i think i have mental illness :3
+    i love cats :3 i love little kitty cats :3 love them :3
+    i love cats :3 i love cats :3 i love cats :3 meow meow :3
+    president barack obama sent a drone strike to a kunduz trauma hospital
+    on october 3rd, 2015 killing 42 civilians and injuring over 30.
+    i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3
+    meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3
+  </ul>
   <!-- mirrors to create illusion of infinite loop! -->
   <ul class="marquee__content" aria-hidden="true">
-      i love cats :3 i love little kitty cats :3 
-      i love little kitties :3 love those little kitty cats :3 
-      i love cats :3 i love little kitty cats :3 
-      i love little kitties :3 love those little kitty cats :3 
-      my name is jeff :3 i adore felines :3 big fan of kitties :3 
-      i love cats :3 i love litte kitties :3 love a pretty kitty :3
-      did you guys know sonic had a rough transition into 3D? 
-      too bad though cause i love my little kitties :3 meow :3 
-      nya nya :3 ppurrr~ :3 i think i have mental illness :3 
-      i love cats :3 i love little kitty cats :3 love them :3 
-      i love cats :3 i love cats :3 i love cats :3 meow meow :3 
-      president barack obama sent a drone strike to a kunduz trauma hospital
-      on october 3rd, 2015 killing 42 civilians and injuring over 30. 
-      i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3 
-      meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3
-    </ul>
+    i love cats :3 i love little kitty cats :3
+    i love little kitties :3 love those little kitty cats :3
+    i love cats :3 i love little kitty cats :3
+    i love little kitties :3 love those little kitty cats :3
+    my name is jeff :3 i adore felines :3 big fan of kitties :3
+    i love cats :3 i love litte kitties :3 love a pretty kitty :3
+    did you guys know sonic had a rough transition into 3D?
+    too bad though cause i love my little kitties :3 meow :3
+    nya nya :3 ppurrr~ :3 i think i have mental illness :3
+    i love cats :3 i love little kitty cats :3 love them :3
+    i love cats :3 i love cats :3 i love cats :3 meow meow :3
+    president barack obama sent a drone strike to a kunduz trauma hospital
+    on october 3rd, 2015 killing 42 civilians and injuring over 30.
+    i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3
+    meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3
+  </ul>
 </div>
 
 <!-- page title -->
-<h1 style="font-family: 'Comic Sans MS';">^_^ !! fangs !! ^_^</h1>
+<h1>^_^ !! fangs !! ^_^</h1>
 
 <!-- meowchi hop gif -->
 <img src="imgs/meowchihop.gif" alt="meowchihop"/>
 
 <!-- email -->
-<p>email me <a href="mailto:hi@catfxngs.com">hi@fangs.cat</a> if you want</p>
+<p>email me <a href="mailto:hi@fangs.cat">hi@fangs.cat</a> if you want</p>
 
 <!-- github placeholder -->
 <p>check out my projects on <a href="https://github.com/catfxngs">github</a></p>
@@ -66,63 +66,70 @@
 
 <!-- personal blog posts -->
 <div class="row">
-    <div class="center">
-      <div class="card">
-        <h2>blog here</h2>
-        <!--<h5>subtitle here</h5>-->
-        <p>
+  <div class="center">
+    <div class="card">
+      <h2>blog here</h2>
+      <!--<h5>subtitle here</h5>-->
+      <p>
         hi, my site is still under construction.
         <br>
         you can have a picture of noni for now!
-        </p>
-        <img src="imgs/nonibaby.jpg" alt="noni being a little cutie"
+      </p>
+      <img
+        src="imgs/nonibaby.jpg"
+        alt="noni being a little cutie"
         width="200"
-        height="200">
-        </div>
+        height="200"
+      />
       </div>
     </div>
+  </div>
 </div>
 
 <!-- display last update -->
-<p><i style="font-size: 12px">*last update: 1/26/2024
-  <br>gallery and music soon :)</i></p>
+<p id="footertext"><i>
+  *last update: 2/21/2024
+  <br>
+  gallery and music soon :)
+</i></p>
 
-  <div class="marquee enable-animation marquee--reverse marquee--bot">
-    <ul class="marquee__content">
-        i love cats :3 i love little kitty cats :3 
-        i love little kitties :3 love those little kitty cats :3 
-        i love cats :3 i love little kitty cats :3 
-        i love little kitties :3 love those little kitty cats :3 
-        my name is jeff :3 i adore felines :3 big fan of kitties :3 
-        i love cats :3 i love litte kitties :3 love a pretty kitty :3
-        did you guys know sonic had a rough transition into 3D? 
-        too bad though cause i love my little kitties :3 meow :3 
-        nya nya :3 ppurrr~ :3 i think i have mental illness :3 
-        i love cats :3 i love little kitty cats :3 love them :3 
-        i love cats :3 i love cats :3 i love cats :3 meow meow :3 
-        president barack obama sent a drone strike to a kunduz trauma hospital
-        on october 3rd, 2015 killing 42 civilians and injuring over 30. 
-        i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3 
-        meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3</ul>
-    <!-- Mirrors the content above -->
-    <ul class="marquee__content" aria-hidden="true">
-        i love cats :3 i love little kitty cats :3 
-        i love little kitties :3 love those little kitty cats :3 
-        i love cats :3 i love little kitty cats :3 
-        i love little kitties :3 love those little kitty cats :3 
-        my name is jeff :3 i adore felines :3 big fan of kitties :3 
-        i love cats :3 i love litte kitties :3 love a pretty kitty :3
-        did you guys know sonic had a rough transition into 3D? 
-        too bad though cause i love my little kitties :3 meow :3 
-        nya nya :3 ppurrr~ :3 i think i have mental illness :3 
-        i love cats :3 i love little kitty cats :3 love them :3 
-        i love cats :3 i love cats :3 i love cats :3 meow meow :3 
-        president barack obama sent a drone strike to a kunduz trauma hospital
-        on october 3rd, 2015 killing 42 civilians and injuring over 30. 
-        i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3 
-        meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3</ul>
-  </div>
+<div class="marquee enable-animation marquee--reverse marquee--bot">
+  <ul class="marquee__content">
+    i love cats :3 i love little kitty cats :3
+    i love little kitties :3 love those little kitty cats :3
+    i love cats :3 i love little kitty cats :3
+    i love little kitties :3 love those little kitty cats :3
+    my name is jeff :3 i adore felines :3 big fan of kitties :3
+    i love cats :3 i love litte kitties :3 love a pretty kitty :3
+    did you guys know sonic had a rough transition into 3D?
+    too bad though cause i love my little kitties :3 meow :3
+    nya nya :3 ppurrr~ :3 i think i have mental illness :3
+    i love cats :3 i love little kitty cats :3 love them :3
+    i love cats :3 i love cats :3 i love cats :3 meow meow :3
+    president barack obama sent a drone strike to a kunduz trauma hospital
+    on october 3rd, 2015 killing 42 civilians and injuring over 30.
+    i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3
+    meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3
+  </ul>
+  <!-- Mirrors the content above -->
+  <ul class="marquee__content" aria-hidden="true">
+    i love cats :3 i love little kitty cats :3
+    i love little kitties :3 love those little kitty cats :3
+    i love cats :3 i love little kitty cats :3
+    i love little kitties :3 love those little kitty cats :3
+    my name is jeff :3 i adore felines :3 big fan of kitties :3
+    i love cats :3 i love litte kitties :3 love a pretty kitty :3
+    did you guys know sonic had a rough transition into 3D?
+    too bad though cause i love my little kitties :3 meow :3
+    nya nya :3 ppurrr~ :3 i think i have mental illness :3
+    i love cats :3 i love little kitty cats :3 love them :3
+    i love cats :3 i love cats :3 i love cats :3 meow meow :3
+    president barack obama sent a drone strike to a kunduz trauma hospital
+    on october 3rd, 2015 killing 42 civilians and injuring over 30.
+    i love cats :3 meow :3 love me a little kitty :3 go kitty go go :3
+    meow :3 woof :3 bark bark :3 i love little kitty cats :3 meow~ :3
+  </ul>
+</div>
 
-</center>
 </body>
 </html>


### PR DESCRIPTION
you're cool so i decided to contribute to your website

ok list of changes:
- dark mode if the user's os theme is dark (no override toggle)
- standardized the tabbing and removed trailing spaces
- removed the `<center>` element and replace with modern implementation
  - specifically `display: flex;` and `align-items: center;`
- remove broken comic sans fontface which fixes it displaying properly
- moved two cases of inline styling to the css
- site title is now "fangs dot cat" instead of "fangs.cat" because it's kinda funny and fits the vibe
- the `mailto` link now goes to the current site name
- made the other `<img>` tag self-closing
- changed the `<ul>` tags to `<p>` tags
- made the class names consistent by using `__` instead of `--`
- replaced that one instance of the r-slur with something more friendly (css went woke)
  - tell me if you don't like this change
- correctly implemented the "pause on hover" effect for the marquees
- the gap variable is now the most common width of a space character: `0.25rem`